### PR TITLE
NTDEV-25675 cisco_xr_show_ipv6_interface.textfsm の修正

### DIFF
--- a/src/NAGATO/templates/cisco_xr_show_ipv6_interface.textfsm
+++ b/src/NAGATO/templates/cisco_xr_show_ipv6_interface.textfsm
@@ -1,11 +1,12 @@
-Value interface (\S+\d+/\d+/\d+/\d+)
-Value status (enabled|stalled|disabled)
-Value link_local_address ([0-9a-f:.]*)
-Value unicast_address ([0-9a-f:.]*)
-Value ip_address ([0-9a-f:.]*\/\d+)
+Value INTERFACE (\S+\d+/\d+/\d+/\d+)
+Value STATUS (enabled|stalled|disabled)
+Value LINK_LOCAL_ADDRESS ([0-9a-f:.]*)
+Value UNICAST_ADDRESS ([0-9a-f:.]*)
+Value SUBNET ([0-9a-f:.]*\/\d+)
 
 Start
- ^${interface}.*$$
- ^\s+IPv6\s+is\s+${status},\s+link-local\s+address\s+is\s+${link_local_address}\s+\[TENTATIVE\]
- ^\s+Global\s+unicast\s+address\(es\):
- ^\s+${unicast_address},\s+subnet\s+is\s+${ip_address}\s+\[TENTATIVE\] -> Record
+  ^${INTERFACE}.*$$
+  ^\s+IPv6\s+is\s+${STATUS},\s+link-local\s+address\s+is\s+${LINK_LOCAL_ADDRESS}\s+\[TENTATIVE\]
+  ^\s+Global\s+unicast\s+address\(es\):
+  ^\s+${UNICAST_ADDRESS},\s+subnet\s+is\s+${SUBNET}\s+\[TENTATIVE\] -> Record
+  ^.*$$


### PR DESCRIPTION
修正内容:
- Value名をすべて大文字に変更
→ntc_templatesと合わせてます。
- Value `ip_address`を`SUBNET`に変更
→CLIの出力にもある通り、やはりここはサブネットを表しています。なのでValue名を合わせました。