### PR TITLE
change values to uppercase

### DIFF
--- a/src/NAGATO/templates/apresia_amios_show_status_card.textfsm
+++ b/src/NAGATO/templates/apresia_amios_show_status_card.textfsm
@@ -1,11 +1,11 @@
-Value Card (Manage\s+\d)
-Value Type (ApCA120-48X|ApCA120-32X8Q2C)
-Value Status (Active|Initializing|Out\s+of\s+service|Fault|Soft\s+updating)
-Value Config (Sync|Unsync|-)
-Value Temp_Major (Normal|Warning|Critical)
-Value Temp_Minor (Normal|High|Low)
-Value Firmware (\d+\.\d+\.\d+|-|Broken|Unknown)
+Value CARD (Manage\s+\d)
+Value TYPE (ApCA120-48X|ApCA120-32X8Q2C)
+Value STATUS (Active|Initializing|Out\s+of\s+service|Fault|Soft\s+updating)
+Value CONFIG (Sync|Unsync|-)
+Value TEMP_MAJOR (Normal|Warning|Critical)
+Value TEMP_MINOR (Normal|High|Low)
+Value FIRMWARE (\d+\.\d+\.\d+|-|Broken|Unknown)
 
 Start
-  ^${Card}\s+${Type}\s+${Status}\s+${Config}\s+${Temp_Major}\s+${Temp_Minor}\s+${Firmware}\s*$$ -> Record
+  ^${CARD}\s+${TYPE}\s+${STATUS}\s+${CONFIG}\s+${TEMP_MAJOR}\s+${TEMP_MINOR}\s+${FIRMWARE}\s*$$ -> Record
   ^.*$$

--- a/src/NAGATO/templates/juniper_junos_show_chassis_environment.textfsm
+++ b/src/NAGATO/templates/juniper_junos_show_chassis_environment.textfsm
@@ -1,7 +1,6 @@
-Value Item (\S+(\s\S+)*)
-Value Status (OK|Check|Absent)
+Value ITEM (\S+(\s\S+)*)
+Value STATUS (OK|Check|Absent)
 
 Start
   ^Class\s+Item\s+Status\s+Measurement$$
-  ^(\w+)?\s+${Item}\s+${Status}\s+.*$$ -> Record
-
+  ^(\w+)?\s+${ITEM}\s+${STATUS}\s+.*$$ -> Record

--- a/src/NAGATO/templates/juniper_junos_show_chassis_routing-engine.textfsm
+++ b/src/NAGATO/templates/juniper_junos_show_chassis_routing-engine.textfsm
@@ -1,7 +1,7 @@
-Value Slot (Slot\s(0|1))
-Value CurrentState (Master|Backup|Disable)
+Value SLOT (Slot\s(0|1))
+Value CURRENTSTATE (Master|Backup|Disable)
 
 Start
   ^Routing\sEngine\sstatus:\s*$$
-  ^\s+${Slot}:$$
-  ^\s+Current\sstate\s+${CurrentState}$$ -> Record
+  ^\s+${SLOT}:$$
+  ^\s+Current\sstate\s+${CURRENTSTATE}$$ -> Record


### PR DESCRIPTION
TextFSMテンプレートのValue名をすべて大文字に変更しました。
ntc-templatesと合わせるためです。