### PR TITLE
NTDEV-36105 Embedded license text

### DIFF
--- a/src/NAGATO/IxNetworkLibrary/__init__.py
+++ b/src/NAGATO/IxNetworkLibrary/__init__.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from robot.api.deco import library
 
 from ._wrapper import IxNetworkRestpyWrapper

--- a/src/NAGATO/IxNetworkLibrary/_wrapper.py
+++ b/src/NAGATO/IxNetworkLibrary/_wrapper.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 import os
 import time
 

--- a/src/NAGATO/NetmikoLibrary/__init__.py
+++ b/src/NAGATO/NetmikoLibrary/__init__.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from robot.api.deco import library
 
 from ._wrapper import NetmikoWrapper

--- a/src/NAGATO/NetmikoLibrary/_wrapper.py
+++ b/src/NAGATO/NetmikoLibrary/_wrapper.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 import os
 from functools import wraps
 from os import PathLike

--- a/src/NAGATO/NetmikoLibrary/apresia/__init__.py
+++ b/src/NAGATO/NetmikoLibrary/apresia/__init__.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from .apresia_amios import AmiosSSH, AmiosTelnet
 
 __all__ = ["AmiosSSH", "AmiosTelnet"]

--- a/src/NAGATO/NetmikoLibrary/apresia/apresia_amios.py
+++ b/src/NAGATO/NetmikoLibrary/apresia/apresia_amios.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 import time
 from typing import Any, Dict, Iterator, List, Optional, Sequence, TextIO, Union
 

--- a/src/NAGATO/NetmikoLibrary/set_templates.py
+++ b/src/NAGATO/NetmikoLibrary/set_templates.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 import os
 import shutil
 from os.path import join

--- a/src/NAGATO/PcapFileReader.py
+++ b/src/NAGATO/PcapFileReader.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from pyshark import FileCapture
 from pyshark.packet.packet import Packet
 from robot.api import logger

--- a/src/NAGATO/Resources/Cisco_IOS_XR.resource
+++ b/src/NAGATO/Resources/Cisco_IOS_XR.resource
@@ -1,3 +1,19 @@
+*** Comments ***
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 *** Settings ***
 Documentation       High-level keywords for operating Cisco IOS-XR
 

--- a/src/NAGATO/Resources/Juniper_Junos.resource
+++ b/src/NAGATO/Resources/Juniper_Junos.resource
@@ -1,3 +1,19 @@
+*** Comments ***
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 *** Settings ***
 Documentation       High-level keywords for operating Juniper Junos
 

--- a/src/NAGATO/SNMP.py
+++ b/src/NAGATO/SNMP.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from pysnmp.error import PySnmpError
 from pysnmp.hlapi import (
     CommunityData,

--- a/src/NAGATO/__init__.py
+++ b/src/NAGATO/__init__.py
@@ -1,3 +1,18 @@
+"""
+Copyright 2024 ITOCHU Techno-Solutions Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 from .IxNetworkLibrary import IxNetworkLibrary
 from .NetmikoLibrary import NetmikoLibrary
 from .PcapFileReader import PcapFileReader


### PR DESCRIPTION
ライセンステキストを埋め込みました。
ソースコードにライセンスを埋め込むのを自動にしようとしたんですが、既にライセンスが埋め込まれているかどうかを判定したり、ライセンス表記をダブらせないように制御したりといったことが手間と感じたので、そこまではしないようにしました。

以下、埋め込むのに作ったスクリプト
```python
lic = """\
Copyright 2024 ITOCHU Techno-Solutions Corporation

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.\
"""

from glob import glob
from pathlib import Path

pythonfiles = glob("src/**/*.py", recursive=True)
resourcefiles = glob("src/**/*.resource", recursive=True)

for file in pythonfiles:
    path = Path(file)
    content = path.read_text()
    content = "\"\"\"\n" + lic + "\"\"\"\n\n" + content
    path.write_text(content)

for file in resourcefiles:
    path = Path(file)
    content = path.read_text()
    content = "*** Comments ***\n" + lic + "\n\n" + content
    path.write_text(content)



```