### PR TITLE
NTDEV-37611 add repository in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ profile = "black"
 [tool.poetry]
 name = "nagato-network"
 version = "0.0.0"
+description = "NAGATO: Network Automation Gears and Test Orchestrator"
+license = "Apache-2.0"
 authors = [
   "Takumi Nohara"
 ]
-description = "NAGATO: Network Automation Gears and Test Orchestrator"
 readme = "README.md"
-license = "Apache-2.0"
+repository = "https://github.com/ctc-nt/NAGATO"
 classifiers = [
   "Framework :: Robot Framework",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
pyproject.tomlの`[tool.poetry]`セクションにrepositoryの情報を加えました。
また、キーを並び替えました。並び順は、[poetryのページ](https://python-poetry.org/docs/pyproject/)に沿うようにしています。